### PR TITLE
Fix recipe: remove CDT deps, add python_min, fix SPDX license

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.0.9" %}
+{% set python_min = "3.6" %}
 
 package:
   name: modestpy
@@ -15,40 +16,12 @@ build:
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
-  build:
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - {{ cdt('libx11-devel') }}          # [linux]
-    - {{ cdt('libxext-devel') }}         # [linux]
-    - {{ cdt('libxrender-devel') }}      # [linux]
-    - {{ cdt('mesa-libgl-devel') }}      # [linux]
-    - {{ cdt('mesa-libegl-devel') }}     # [linux]
-    - {{ cdt('mesa-dri-drivers') }}      # [linux]
-    - {{ cdt('libxau-devel') }}          # [linux]
-    - {{ cdt('alsa-lib-devel') }}        # [linux]
-    - {{ cdt('gtk2-devel') }}            # [linux]
-    - {{ cdt('gtkmm24-devel') }}         # [linux]
-    - {{ cdt('libdrm-devel') }}          # [linux]
-    - {{ cdt('libxcomposite-devel') }}   # [linux]
-    - {{ cdt('libxcursor-devel') }}      # [linux]
-    - {{ cdt('libxi-devel') }}           # [linux]
-    - {{ cdt('libxrandr-devel') }}       # [linux]
-    - {{ cdt('pciutils-devel') }}        # [linux]
-    - {{ cdt('libxscrnsaver-devel') }}   # [linux]
-    - {{ cdt('libxtst-devel') }}         # [linux]
-    - {{ cdt('libselinux-devel') }}      # [linux]
-    - {{ cdt('libxdamage') }}            # [linux]
-    - {{ cdt('libxdamage-devel') }}      # [linux]
-    - {{ cdt('libxfixes') }}             # [linux]
-    - {{ cdt('libxfixes-devel') }}       # [linux]
-    - {{ cdt('libxxf86vm') }}            # [linux]
-    - {{ cdt('libxrandr') }}             # [linux]
-    - {{ cdt('alsa-lib') }}              # [linux]
   host:
     - pip
     - setuptools
-    - python
+    - python {{ python_min }}
   run:
-    - python
+    - python >={{ python_min }}
     - scipy
     - pandas
     - matplotlib-base
@@ -67,7 +40,7 @@ test:
 
 about:
   home: https://github.com/sdu-cfei/modest-py
-  license: BSD 2-clause
+  license: BSD-2-Clause
   license_file: LICENSE
   summary: FMI-compliant Model Estimation in Python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - pyfmi
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - modestpy
     - modestpy.estim


### PR DESCRIPTION
## Summary
- Remove all CDT build dependencies with `# [linux]` platform selectors (incompatible with `noarch: python`)
- Add `python_min` Jinja2 variable and use it for python version pins in host/run
- Fix license to valid SPDX identifier: `BSD-2-Clause`

Addresses linter issues flagged on #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)